### PR TITLE
Support CRUD operations for Linode instance disks

### DIFF
--- a/lib/fog/linode/compute.rb
+++ b/lib/fog/linode/compute.rb
@@ -20,6 +20,11 @@ module Fog
       request :view_server
       request :update_server
       request :delete_server
+      request :create_disk
+      request :list_disks
+      request :view_disk
+      request :update_disk
+      request :delete_disk
 
       model_path 'fog/linode/compute/models'
       collection :types

--- a/lib/fog/linode/compute/models/disk.rb
+++ b/lib/fog/linode/compute/models/disk.rb
@@ -1,0 +1,46 @@
+module Fog
+  module Linode
+    class Compute
+      # Model for Linode instance disks
+      class Disk < Fog::Model
+        identity :id
+
+        attribute :server_id
+        attribute :label
+        attribute :status
+        attribute :size
+        attribute :filesystem
+        attribute :created
+        attribute :updated
+
+        # Attributes for Disk creation (not supported on view/update)
+        attribute :read_only
+        attribute :image
+        attribute :authorized_keys
+        attribute :authorized_users
+        attribute :root_pass
+        attribute :stackscript_id
+
+        def save
+          if identity.nil?
+            merge_attributes(service.create_disk(server_id, attributes))
+          else
+            merge_attributes(service.update_disk(server_id, identity, attributes_for_update))
+          end
+        end
+
+        def destroy
+          requires :identity
+          service.delete_disk(identity)
+        end
+
+        private
+
+        def attributes_for_update
+          supported_attributes = %i[label filesystem]
+          attributes.dup.select { |key| supported_attributes.include? key }
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/linode/compute/models/disks.rb
+++ b/lib/fog/linode/compute/models/disks.rb
@@ -1,0 +1,29 @@
+require 'fog/linode/paginated_collection'
+
+module Fog
+  module Linode
+    class Compute
+      # Collection class for loading Disk models from Linode instance disk data
+      class Disks < Fog::Collection
+        model Disk
+
+        def all(server_id, options = {})
+          disks = service.list_disks(server_id, options)
+          load(disks.map { |disk| add_server_id(server_id, disk) })
+        end
+
+        def get(server_id, disk_id)
+          disk = service.view_disk(server_id, disk_id)
+          new add_server_id(server_id, disk)
+        end
+
+        private
+
+        def add_server_id(server_id, disk)
+          disk['server_id'] = server_id
+          disk
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/linode/compute/requests/create_disk.rb
+++ b/lib/fog/linode/compute/requests/create_disk.rb
@@ -1,0 +1,22 @@
+module Fog
+  module Linode
+    class Compute
+      # This class provides the actual implementation for service calls
+      class Real
+        def create_disk(linode_id, options = {})
+          response = request(
+            expects: [200],
+            method: 'POST',
+            path: "linode/instances/#{linode_id}/disks",
+            body: Fog::JSON.encode(options),
+            headers: {
+              'Content-Type' => 'application/json'
+            }
+          )
+
+          response.body
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/linode/compute/requests/delete_disk.rb
+++ b/lib/fog/linode/compute/requests/delete_disk.rb
@@ -1,0 +1,17 @@
+module Fog
+  module Linode
+    class Compute
+      # This class provides the actual implementation for service calls
+      class Real
+        def delete_disk(linode_id, disk_id)
+          response = request(
+            expects: [200],
+            method: 'DELETE',
+            path: "linode/instances/#{linode_id}/disks/#{disk_id}"
+          )
+          response.body
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/linode/compute/requests/list_disks.rb
+++ b/lib/fog/linode/compute/requests/list_disks.rb
@@ -1,0 +1,14 @@
+module Fog
+  module Linode
+    class Compute
+      # This class provides the actual implementation for service calls
+      class Real
+        include PaginatedCollection
+
+        def list_disks(linode_id, options = {})
+          make_paginated_request("linode/instances/#{linode_id}/disks", options)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/linode/compute/requests/update_disk.rb
+++ b/lib/fog/linode/compute/requests/update_disk.rb
@@ -1,0 +1,22 @@
+module Fog
+  module Linode
+    class Compute
+      # This class provides the actual implementation for service calls
+      class Real
+        def update_disk(linode_id, disk_id, options = {})
+          response = request(
+            expects: [200],
+            method: 'PUT',
+            path: "linode/instances/#{linode_id}/disks/#{disk_id}",
+            body: Fog::JSON.encode(options),
+            headers: {
+              'Content-Type' => 'application/json'
+            }
+          )
+
+          response.body
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/linode/compute/requests/view_disk.rb
+++ b/lib/fog/linode/compute/requests/view_disk.rb
@@ -1,0 +1,21 @@
+module Fog
+  module Linode
+    class Compute
+      # This class provides the actual implementation for service calls
+      class Real
+        def view_disk(linode_id, disk_id, _options = {})
+          response = request(
+            expects: [200],
+            method: 'GET',
+            path: "linode/instances/#{linode_id}/disks/#{disk_id}",
+            headers: {
+              'Content-Type' => 'application/json'
+            }
+          )
+
+          response.body
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/create_disk.yml
+++ b/spec/cassettes/create_disk.yml
@@ -1,0 +1,76 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.linode.com/v4/linode/instances/14022202/disks
+    body:
+      encoding: UTF-8
+      string: '{"size":10000,"label":"create_disk_spec"}'
+    headers:
+      Authorization:
+      - Bearer <LINODE_TOKEN>
+      User-Agent:
+      - fog-linode/0.0.1.rc2 fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 16 May 2019 14:27:18 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '173'
+      Connection:
+      - keep-alive
+      X-Oauth-Scopes:
+      - "*"
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_write
+      X-Frame-Options:
+      - DENY, DENY
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      X-Spec-Version:
+      - 4.0.22
+      X-Ratelimit-Limit:
+      - '400'
+      X-Ratelimit-Remaining:
+      - '399'
+      X-Ratelimit-Reset:
+      - '1558016958'
+      Retry-After:
+      - '119'
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Authorization, X-Filter
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: ASCII-8BIT
+      string: '{"updated": "2019-05-16T14:27:18", "size": 10000, "filesystem": "ext4",
+        "id": 29200416, "status": "not ready", "label": "create_disk_spec", "created":
+        "2019-05-16T14:27:18"}'
+    http_version: 
+  recorded_at: Thu, 16 May 2019 14:27:18 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/delete_disk.yml
+++ b/spec/cassettes/delete_disk.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://api.linode.com/v4/linode/instances/14022202/disks/29200416
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <LINODE_TOKEN>
+      User-Agent:
+      - fog-linode/0.0.1.rc2 fog-core/1.45.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 16 May 2019 14:57:08 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+      Connection:
+      - keep-alive
+      X-Oauth-Scopes:
+      - "*"
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_write
+      X-Frame-Options:
+      - DENY, DENY
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      X-Spec-Version:
+      - 4.0.22
+      X-Ratelimit-Limit:
+      - '400'
+      X-Ratelimit-Remaining:
+      - '399'
+      X-Ratelimit-Reset:
+      - '1558018748'
+      Retry-After:
+      - '119'
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Authorization, X-Filter
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: ASCII-8BIT
+      string: "{}"
+    http_version: 
+  recorded_at: Thu, 16 May 2019 14:57:09 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/list_disks.yml
+++ b/spec/cassettes/list_disks.yml
@@ -1,0 +1,78 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.linode.com/v4/linode/instances/14022202/disks
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <LINODE_TOKEN>
+      User-Agent:
+      - fog-linode/0.0.1.rc2 fog-core/1.45.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 16 May 2019 14:29:51 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '564'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store, private, max-age=60, s-maxage=60
+      X-Oauth-Scopes:
+      - "*"
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_only
+      X-Frame-Options:
+      - DENY, DENY
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      X-Spec-Version:
+      - 4.0.22
+      Vary:
+      - Authorization, X-Filter, Authorization, X-Filter
+      X-Ratelimit-Limit:
+      - '400'
+      X-Ratelimit-Remaining:
+      - '399'
+      X-Ratelimit-Reset:
+      - '1558017110'
+      Retry-After:
+      - '118'
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: ASCII-8BIT
+      string: '{"results": 3, "pages": 1, "page": 1, "data": [{"id": 29171265, "status":
+        "ready", "label": "Ubuntu 18.04 LTS Disk", "updated": "2019-05-16T14:27:10",
+        "filesystem": "ext4", "size": 40688, "created": "2019-05-15T18:58:51"}, {"id":
+        29171266, "status": "ready", "label": "512 MB Swap Image", "updated": "2019-05-15T18:59:16",
+        "filesystem": "swap", "size": 512, "created": "2019-05-15T18:58:51"}, {"id":
+        29200416, "status": "ready", "label": "update_disk_spec", "updated": "2019-05-16T14:29:51",
+        "filesystem": "ext4", "size": 10000, "created": "2019-05-16T14:27:19"}]}'
+    http_version: 
+  recorded_at: Thu, 16 May 2019 14:29:51 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/update_disk.yml
+++ b/spec/cassettes/update_disk.yml
@@ -1,0 +1,131 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://api.linode.com/v4/linode/instances/14022202/disks/12777316
+    body:
+      encoding: UTF-8
+      string: '{"type":"CNAME","name":"alias.charlestreatman.com","target":"newtarget.charlestreatman.com"}'
+    headers:
+      Authorization:
+      - Bearer <LINODE_TOKEN>
+      User-Agent:
+      - fog-linode/0.0.1.rc2 fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: NOT FOUND
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 16 May 2019 14:27:19 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '37'
+      Connection:
+      - keep-alive
+      X-Oauth-Scopes:
+      - "*"
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_write
+      X-Frame-Options:
+      - DENY
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      X-Spec-Version:
+      - 4.0.22
+      X-Ratelimit-Limit:
+      - '400'
+      X-Ratelimit-Remaining:
+      - '399'
+      X-Ratelimit-Reset:
+      - '1558016958'
+      Retry-After:
+      - '118'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"errors": [{"reason": "Not found"}]}'
+    http_version: 
+  recorded_at: Thu, 16 May 2019 14:27:19 GMT
+- request:
+    method: put
+    uri: https://api.linode.com/v4/linode/instances/14022202/disks/29200416
+    body:
+      encoding: UTF-8
+      string: '{"label":"update_disk_spec"}'
+    headers:
+      Authorization:
+      - Bearer <LINODE_TOKEN>
+      User-Agent:
+      - fog-linode/0.0.1.rc2 fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 16 May 2019 14:29:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '169'
+      Connection:
+      - keep-alive
+      X-Oauth-Scopes:
+      - "*"
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_write
+      X-Frame-Options:
+      - DENY, DENY
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      X-Spec-Version:
+      - 4.0.22
+      X-Ratelimit-Limit:
+      - '400'
+      X-Ratelimit-Remaining:
+      - '399'
+      X-Ratelimit-Reset:
+      - '1558017110'
+      Retry-After:
+      - '119'
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Content-Security-Policy:
+      - default-src 'none'
+      Vary:
+      - Authorization, X-Filter
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: ASCII-8BIT
+      string: '{"updated": "2019-05-16T14:29:51", "created": "2019-05-16T14:27:19",
+        "label": "update_disk_spec", "filesystem": "ext4", "size": 10000, "status":
+        "ready", "id": 29200416}'
+    http_version: 
+  recorded_at: Thu, 16 May 2019 14:29:50 GMT
+recorded_with: VCR 4.0.0

--- a/spec/cassettes/view_disk.yml
+++ b/spec/cassettes/view_disk.yml
@@ -1,0 +1,135 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.linode.com/v4/linode/instances/14022202/disks/12777316
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <LINODE_TOKEN>
+      User-Agent:
+      - fog-linode/0.0.1.rc2 fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 404
+      message: NOT FOUND
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 16 May 2019 14:27:18 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '37'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store
+      X-Oauth-Scopes:
+      - "*"
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_only
+      X-Frame-Options:
+      - DENY
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      X-Spec-Version:
+      - 4.0.22
+      Vary:
+      - Authorization, X-Filter
+      X-Ratelimit-Limit:
+      - '400'
+      X-Ratelimit-Remaining:
+      - '399'
+      X-Ratelimit-Reset:
+      - '1558016958'
+      Retry-After:
+      - '119'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"errors": [{"reason": "Not found"}]}'
+    http_version: 
+  recorded_at: Thu, 16 May 2019 14:27:18 GMT
+- request:
+    method: get
+    uri: https://api.linode.com/v4/linode/instances/14022202/disks/29200416
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <LINODE_TOKEN>
+      User-Agent:
+      - fog-linode/0.0.1.rc2 fog-core/1.45.0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 16 May 2019 14:29:50 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '169'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - private, max-age=0, s-maxage=0, no-cache, no-store, private, max-age=60, s-maxage=60
+      X-Oauth-Scopes:
+      - "*"
+      X-Accepted-Oauth-Scopes:
+      - linodes:read_only
+      X-Frame-Options:
+      - DENY, DENY
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      X-Spec-Version:
+      - 4.0.22
+      Vary:
+      - Authorization, X-Filter, Authorization, X-Filter
+      X-Ratelimit-Limit:
+      - '400'
+      X-Ratelimit-Remaining:
+      - '399'
+      X-Ratelimit-Reset:
+      - '1558017110'
+      Retry-After:
+      - '119'
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Expose-Headers:
+      - X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Status
+      Content-Security-Policy:
+      - default-src 'none'
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: ASCII-8BIT
+      string: '{"updated": "2019-05-16T14:27:22", "created": "2019-05-16T14:27:19",
+        "label": "create_disk_spec", "filesystem": "ext4", "size": 10000, "status":
+        "ready", "id": 29200416}'
+    http_version: 
+  recorded_at: Thu, 16 May 2019 14:29:50 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fog/linode/compute/requests/create_disk_spec.rb
+++ b/spec/fog/linode/compute/requests/create_disk_spec.rb
@@ -1,0 +1,29 @@
+require 'minitest_helper'
+
+describe Fog::Linode::Compute do
+  describe '#create_disk' do
+    before do
+      VCR.insert_cassette('create_disk')
+    end
+
+    after do
+      VCR.eject_cassette
+    end
+
+    let(:connection) do
+      Fog::Compute.new(
+        provider: :linode,
+        linode_token: ENV['LINODE_TOKEN'] || 'fake_token'
+      )
+    end
+
+    it 'creates a disk for the specified Linode instance' do
+      server_id = 14022202
+      disk = connection.create_disk(server_id,
+                                    size: 10000,
+                                    label: 'create_disk_spec')
+      assert !disk['id'].nil?
+      assert_equal disk['size'], 10000
+    end
+  end
+end

--- a/spec/fog/linode/compute/requests/delete_disk_spec.rb
+++ b/spec/fog/linode/compute/requests/delete_disk_spec.rb
@@ -1,0 +1,27 @@
+require 'minitest_helper'
+
+describe Fog::Linode::Compute do
+  describe '#delete_disk' do
+    before do
+      VCR.insert_cassette('delete_disk')
+    end
+
+    after do
+      VCR.eject_cassette
+    end
+
+    let(:connection) do
+      Fog::Compute.new(
+        provider: :linode,
+        linode_token: ENV['LINODE_TOKEN'] || 'fake_token'
+      )
+    end
+
+    it 'deletes the specified disk' do
+      server_id = 14022202
+      disk_id = 29200416
+      response = connection.delete_disk(server_id, disk_id)
+      assert_empty response
+    end
+  end
+end

--- a/spec/fog/linode/compute/requests/list_disks_spec.rb
+++ b/spec/fog/linode/compute/requests/list_disks_spec.rb
@@ -1,0 +1,27 @@
+require 'minitest_helper'
+
+describe Fog::Linode::Compute do
+  describe '#list_disks' do
+    before do
+      VCR.insert_cassette('list_disks')
+    end
+
+    after do
+      VCR.eject_cassette
+    end
+
+    let(:connection) do
+      Fog::Compute.new(
+        provider: :linode,
+        linode_token: ENV['LINODE_TOKEN'] || 'fake_token'
+      )
+    end
+
+    it 'lists existing disks for the specified Linode instance' do
+      linode_id = 14022202
+      disks = connection.list_disks(linode_id)
+      assert !disks.empty?
+      assert !disks.first['filesystem'].nil?
+    end
+  end
+end

--- a/spec/fog/linode/compute/requests/update_disk_spec.rb
+++ b/spec/fog/linode/compute/requests/update_disk_spec.rb
@@ -1,0 +1,30 @@
+require 'minitest_helper'
+
+describe Fog::Linode::Compute do
+  describe '#update_disk' do
+    before do
+      VCR.insert_cassette('update_disk')
+    end
+
+    after do
+      VCR.eject_cassette
+    end
+
+    let(:connection) do
+      Fog::Compute.new(
+        provider: :linode,
+        linode_token: ENV['LINODE_TOKEN'] || 'fake_token'
+      )
+    end
+
+    it 'updates the specified disk' do
+      server_id = 14022202
+      disk_id = 29200416
+      disk = connection.update_disk(server_id,
+                                    disk_id,
+                                    label: 'update_disk_spec')
+      assert_equal disk['id'], disk_id
+      assert_equal disk['label'], 'update_disk_spec'
+    end
+  end
+end

--- a/spec/fog/linode/compute/requests/view_disk_spec.rb
+++ b/spec/fog/linode/compute/requests/view_disk_spec.rb
@@ -1,0 +1,28 @@
+require 'minitest_helper'
+
+describe Fog::Linode::Compute do
+  describe '#view_disk' do
+    before do
+      VCR.insert_cassette('view_disk')
+    end
+
+    after do
+      VCR.eject_cassette
+    end
+
+    let(:connection) do
+      Fog::Compute.new(
+        provider: :linode,
+        linode_token: ENV['LINODE_TOKEN'] || 'fake_token'
+      )
+    end
+
+    it 'loads the specified disk' do
+      server_id = 14022202
+      disk_id = 29200416
+      disk = connection.view_disk(server_id, disk_id)
+      assert_equal disk['id'], disk_id
+      assert !disk['filesystem'].nil?
+    end
+  end
+end


### PR DESCRIPTION
This supports the basic create/read/update/delete operations for
Linode instance disks in order to get parity with the existing
Fog provider for Linode APIv3.  Additional actions in Linode API
v4, such as resizing a disk, are not implemented yet.