### PR TITLE
add ready? server check

### DIFF
--- a/lib/fog/linode/compute/models/server.rb
+++ b/lib/fog/linode/compute/models/server.rb
@@ -49,6 +49,10 @@ module Fog
           service.delete_server(identity)
         end
 
+        def ready?
+          status == 'running'
+        end
+
         private
 
         def attributes_for_update


### PR DESCRIPTION
This appears to be a common pattern.

https://github.com/fog/fog/blob/master/CONTRIBUTING.md#highlights-4

As I was migrating a project from fog to fog-linode, I realized it was missing.