### PR TITLE
Update spec homepage to fog GitHub org

### DIFF
--- a/fog-linode.gemspec
+++ b/fog-linode.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary       = "Module for the 'fog' gem to support Linode cloud services."
   spec.description   = "This library can be used as a module for 'fog' or as standalone provider
                         to use the Linode cloud services in applications."
-  spec.homepage      = 'https://github.com/Linode/fog-linode'
+  spec.homepage      = 'https://github.com/fog/fog-linode'
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
The updates `spec.homepage` to point to the current source code repository.